### PR TITLE
fly.toml: set `min_machines_running` to 0

### DIFF
--- a/llm/fly.toml
+++ b/llm/fly.toml
@@ -18,7 +18,7 @@ initial_size = '100gb'
 internal_port = 11434
 auto_stop_machines = true
 auto_start_machines = true
-min_machines_running = 1
+min_machines_running = 0
 processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
The default fly.toml sets `min_machines_running` to 1, which is no good for a GPU appliance you want to shut down when idle. It's a real gotcha; I was wondering why my Ollama Machine was always awake!