### PR TITLE
Update fly.toml to use Flycast

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ primary_region = 'dfw'
 [build]
 
 [env]
-OLLAMA_API = 'http://llm-describer-llama.internal:11434'
+OLLAMA_API = 'http://llm-describer-llama.flycast'
 
 [[mounts]]
 source = 'data'
@@ -18,7 +18,7 @@ initial_size = '10gb'
 
 [http_service]
 internal_port = 8090
-force_https = true
+force_https = false
 auto_stop_machines = true
 auto_start_machines = true
 min_machines_running = 0


### PR DESCRIPTION
* changed the OLLAMA_API env variable from a 6PN .internal address to a Flycast one so that Fly Proxy can autostart and autostop the Ollama Machine.
* changed the `force_https` option to false for the HTTP service since Flycast doesn't have certs